### PR TITLE
Remove questions that do not use StringPools, add StringPools where needed and remove the support of the old version of the Questions

### DIFF
--- a/app/src/androidTest/java/ch/epfl/qedit/edit/EditOverviewFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/edit/EditOverviewFragmentTest.java
@@ -12,9 +12,9 @@ import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static ch.epfl.qedit.model.StringPool.TITLE_ID;
 import static ch.epfl.qedit.util.DragAndDropAction.dragAndDrop;
-import static ch.epfl.qedit.util.Util.createMockQuiz;
+import static ch.epfl.qedit.util.Util.createTestQuiz;
+import static ch.epfl.qedit.util.Util.createTestStringPool;
 import static ch.epfl.qedit.view.edit.EditOverviewFragment.NEW_QUESTION_REQUEST_CODE;
 import static ch.epfl.qedit.view.edit.EditOverviewFragment.QUESTION;
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.STRING_POOL;
@@ -44,7 +44,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class EditOverviewFragmentTest extends RecyclerViewHelpers {
-    private static final Quiz mockQuiz = createMockQuiz("TestTitle");
+    private static final Quiz testQuiz = createTestQuiz();
+    private static final StringPool stringPool = createTestStringPool("TestTitle");
 
     @Rule
     public final FragmentTestRule<?, EditOverviewFragment> testRule =
@@ -57,10 +58,7 @@ public class EditOverviewFragmentTest extends RecyclerViewHelpers {
     @Before
     public void setUp() {
         Intents.init();
-        Quiz.Builder quizBuilder = new Quiz.Builder(mockQuiz);
-
-        StringPool stringPool = new StringPool();
-        stringPool.update(TITLE_ID, mockQuiz.getTitle());
+        Quiz.Builder quizBuilder = new Quiz.Builder(testQuiz);
 
         EditionViewModel model =
                 new ViewModelProvider(testRule.getActivity()).get(EditionViewModel.class);
@@ -107,7 +105,7 @@ public class EditOverviewFragmentTest extends RecyclerViewHelpers {
     public void testCanDeleteItem() {
         item(0).perform(click());
         itemView(0, R.id.delete_button).perform(click());
-        onView(withText(mockQuiz.getQuestions().get(0).getTitle())).check(doesNotExist());
+        onView(withText(testQuiz.getQuestions().get(0).getTitle())).check(doesNotExist());
         assertOverlayAt(-1, 4);
     }
 
@@ -149,10 +147,10 @@ public class EditOverviewFragmentTest extends RecyclerViewHelpers {
     }
 
     private String[] getTitles() {
-        String[] titles = new String[mockQuiz.getQuestions().size()];
+        String[] titles = new String[testQuiz.getQuestions().size()];
 
         for (int i = 0; i < titles.length; ++i) {
-            titles[i] = mockQuiz.getQuestions().get(i).getTitle();
+            titles[i] = stringPool.get(testQuiz.getQuestions().get(i).getTitle());
         }
 
         return titles;
@@ -195,7 +193,7 @@ public class EditOverviewFragmentTest extends RecyclerViewHelpers {
     public void testEmptyHint() {
         onView(withId(R.id.empty_list_hint)).check(matches(not(isDisplayed())));
 
-        for (int i = 0; i < mockQuiz.getQuestions().size(); ++i) {
+        for (int i = 0; i < testQuiz.getQuestions().size(); ++i) {
             item(0).perform(click());
             itemView(0, R.id.delete_button).perform(click());
         }

--- a/app/src/androidTest/java/ch/epfl/qedit/edit/EditPreviewFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/edit/EditPreviewFragmentTest.java
@@ -4,8 +4,8 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static ch.epfl.qedit.model.StringPool.TITLE_ID;
-import static ch.epfl.qedit.util.Util.createMockQuiz;
+import static ch.epfl.qedit.util.Util.createTestQuiz;
+import static ch.epfl.qedit.util.Util.createTestStringPool;
 
 import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
@@ -21,11 +21,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class EditPreviewFragmentTest {
-    private static final String testTitle = "TestTitle";
-    private static final String testNoTitle = "No TestTitle";
-    private static final String testNoText = "No TestQuestionText";
+    private static final Quiz testQuiz = createTestQuiz();
+    private static final StringPool stringPool = createTestStringPool("TestTitle");
 
-    private static final Quiz mockQuiz = createMockQuiz(testTitle);
     private EditionViewModel model;
 
     @Rule
@@ -34,10 +32,7 @@ public class EditPreviewFragmentTest {
 
     @Before
     public void setUp() {
-        StringPool stringPool = new StringPool();
-        stringPool.update(TITLE_ID, testTitle);
-
-        Quiz.Builder quizBuilder = new Quiz.Builder(mockQuiz);
+        Quiz.Builder quizBuilder = new Quiz.Builder(testQuiz);
 
         model = new ViewModelProvider(testRule.getActivity()).get(EditionViewModel.class);
 
@@ -60,9 +55,12 @@ public class EditPreviewFragmentTest {
 
     @Test
     public void testFragmentDisplaysFilledQuestionCorrectly() {
-        Question question = mockQuiz.getQuestions().get(0);
+        Question question = testQuiz.getQuestions().get(0);
         model.getFocusedQuestion().postValue(0);
-        onView(withId(R.id.question_title)).check(matches(withText(question.getTitle())));
-        onView(withId(R.id.question_display)).check(matches(withText(question.getText())));
+
+        onView(withId(R.id.question_title))
+                .check(matches(withText(stringPool.get(question.getTitle()))));
+        onView(withId(R.id.question_display))
+                .check(matches(withText(stringPool.get(question.getText()))));
     }
 }

--- a/app/src/androidTest/java/ch/epfl/qedit/edit/EditQuizActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/edit/EditQuizActivityTest.java
@@ -9,7 +9,8 @@ import static androidx.test.espresso.contrib.ActivityResultMatchers.hasResultDat
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static ch.epfl.qedit.util.Util.createMockQuiz;
+import static ch.epfl.qedit.util.Util.createTestQuiz;
+import static ch.epfl.qedit.util.Util.createTestStringPool;
 import static ch.epfl.qedit.view.edit.EditSettingsActivity.QUIZ_BUILDER;
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.QUIZ_ID;
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.STRING_POOL;
@@ -31,6 +32,7 @@ import org.junit.Test;
 
 public class EditQuizActivityTest {
     private Quiz quiz;
+    private StringPool stringPool;
 
     @Rule
     public final IntentsTestRule<EditQuizActivity> testRule =
@@ -38,9 +40,9 @@ public class EditQuizActivityTest {
 
     @Before
     public void setUp() {
-        quiz = createMockQuiz("Test");
+        quiz = createTestQuiz();
         Quiz.Builder quizBuilder = new Quiz.Builder(quiz);
-        StringPool stringPool = new StringPool();
+        stringPool = createTestStringPool("Title");
 
         Intent intent = new Intent();
         Bundle bundle = new Bundle();
@@ -74,7 +76,7 @@ public class EditQuizActivityTest {
         onView(withId(R.id.next)).perform(click());
 
         onView(withId(R.id.question_title))
-                .check(matches(withText(quiz.getQuestions().get(1).getTitle())));
+                .check(matches(withText(stringPool.get(quiz.getQuestions().get(1).getTitle()))));
 
         onView(withId(R.id.quiz_overview_container)).check(matches(isDisplayed()));
         onView(withId(R.id.question_details_container)).check(matches(isDisplayed()));

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
@@ -12,7 +12,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static ch.epfl.qedit.model.StringPool.TITLE_ID;
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.QUIZ_ID;
-import static ch.epfl.qedit.view.home.HomeQuizListFragment.STRING_POOL;
 import static ch.epfl.qedit.view.quiz.QuestionFragment.FRAGMENT_TAG;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.core.Is.is;
@@ -55,16 +54,15 @@ public class QuizActivityTest {
         Intent intent = new Intent();
         Bundle bundle = new Bundle();
 
-        initializeQuizAndStringPool();
+        initializeStringPoolAndQuiz();
 
         bundle.putSerializable(QUIZ_ID, quiz);
-        bundle.putSerializable(STRING_POOL, stringPool);
         intent.putExtras(bundle);
 
         testRule.launchActivity(intent);
 
         model = new ViewModelProvider(testRule.getActivity()).get(QuizViewModel.class);
-        model.initialize(quiz, stringPool);
+        model.setQuiz(quiz.instantiateLanguage(stringPool));
 
         final MatrixModel matrixModel = new MatrixModel(1, 1);
         matrixModel.updateAnswer(0, 0, answer1);
@@ -81,7 +79,7 @@ public class QuizActivityTest {
         testRule.finishActivity();
     }
 
-    private void initializeQuizAndStringPool() {
+    private void initializeStringPoolAndQuiz() {
         stringPool = new StringPool();
         stringPool.update(TITLE_ID, "Title");
 
@@ -97,7 +95,7 @@ public class QuizActivityTest {
                                 stringPool.add("Fill this Vector!"),
                                 "matrix7x1"));
 
-        quiz = builder.build();
+        quiz = builder.build().instantiateLanguage(stringPool);
     }
 
     @Test

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
@@ -41,6 +41,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class QuizActivityTest {
+    private Quiz quiz;
+    private StringPool stringPool;
     private QuizViewModel model;
     private final Integer zero = 0;
     private final String answer1 = "1234";
@@ -52,22 +54,8 @@ public class QuizActivityTest {
     public void launchActivity() {
         Intent intent = new Intent();
         Bundle bundle = new Bundle();
-        StringPool stringPool = new StringPool();
-        stringPool.update(TITLE_ID, "Title");
 
-        Quiz.Builder builder = new Quiz.Builder();
-        builder.append(
-                        new Question(
-                                stringPool.add("Bananas"),
-                                stringPool.add("How many?"),
-                                "matrix1x1"))
-                .append(
-                        new Question(
-                                stringPool.add("Vector"),
-                                stringPool.add("Fill this Vector!"),
-                                "matrix7x1"));
-
-        Quiz quiz = builder.build();
+        initializeQuizAndStringPool();
 
         bundle.putSerializable(QUIZ_ID, quiz);
         bundle.putSerializable(STRING_POOL, stringPool);
@@ -91,6 +79,25 @@ public class QuizActivityTest {
 
     public void finishActivity() {
         testRule.finishActivity();
+    }
+
+    private void initializeQuizAndStringPool() {
+        stringPool = new StringPool();
+        stringPool.update(TITLE_ID, "Title");
+
+        Quiz.Builder builder = new Quiz.Builder();
+        builder.append(
+                        new Question(
+                                stringPool.add("Bananas"),
+                                stringPool.add("How many?"),
+                                "matrix1x1"))
+                .append(
+                        new Question(
+                                stringPool.add("Vector"),
+                                stringPool.add("Fill this Vector!"),
+                                "matrix7x1"));
+
+        quiz = builder.build();
     }
 
     @Test
@@ -163,7 +170,6 @@ public class QuizActivityTest {
     public void testDoneNoCLicked() {
         launchActivity();
         onView(withId(R.id.validate)).perform(click());
-        // onView(withText("No")).inRoot(isDialog()).perform(click());
         onView(withId(android.R.id.button2)).perform(click());
         finishActivity();
     }
@@ -173,8 +179,7 @@ public class QuizActivityTest {
         launchActivity();
         onView(withId(R.id.validate)).perform(click());
         onView(withId(android.R.id.button1)).perform(click());
-        // onView(withText("Yes")).inRoot(isDialog()).perform(click());
-        onView(withText("number of good answers = 0"))
+            onView(withText("number of good answers = 0"))
                 .inRoot(
                         withDecorView(
                                 Matchers.not(

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
@@ -10,7 +10,9 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static ch.epfl.qedit.model.StringPool.TITLE_ID;
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.QUIZ_ID;
+import static ch.epfl.qedit.view.home.HomeQuizListFragment.STRING_POOL;
 import static ch.epfl.qedit.view.quiz.QuestionFragment.FRAGMENT_TAG;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.core.Is.is;
@@ -24,12 +26,12 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
 import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import ch.epfl.qedit.model.answer.MatrixModel;
 import ch.epfl.qedit.view.answer.MatrixFragment;
 import ch.epfl.qedit.view.quiz.QuizActivity;
 import ch.epfl.qedit.viewmodel.QuizViewModel;
-import java.util.Arrays;
 import java.util.HashMap;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -50,19 +52,31 @@ public class QuizActivityTest {
     public void launchActivity() {
         Intent intent = new Intent();
         Bundle bundle = new Bundle();
-        Quiz quiz =
-                new Quiz(
-                        "Title",
-                        Arrays.asList(
-                                new Question("Banane", "How many?", "matrix1x1"),
-                                new Question("Vector", "Fill this Vector!", "matrix7x1")));
+        StringPool stringPool = new StringPool();
+        stringPool.update(TITLE_ID, "Title");
+
+        Quiz.Builder builder = new Quiz.Builder();
+        builder.append(
+                        new Question(
+                                stringPool.add("Bananas"),
+                                stringPool.add("How many?"),
+                                "matrix1x1"))
+                .append(
+                        new Question(
+                                stringPool.add("Vector"),
+                                stringPool.add("Fill this Vector!"),
+                                "matrix7x1"));
+
+        Quiz quiz = builder.build();
+
         bundle.putSerializable(QUIZ_ID, quiz);
+        bundle.putSerializable(STRING_POOL, stringPool);
         intent.putExtras(bundle);
 
         testRule.launchActivity(intent);
 
         model = new ViewModelProvider(testRule.getActivity()).get(QuizViewModel.class);
-        model.setQuiz(quiz);
+        model.initialize(quiz, stringPool);
 
         final MatrixModel matrixModel = new MatrixModel(1, 1);
         matrixModel.updateAnswer(0, 0, answer1);

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizActivityTest.java
@@ -179,7 +179,7 @@ public class QuizActivityTest {
         launchActivity();
         onView(withId(R.id.validate)).perform(click());
         onView(withId(android.R.id.button1)).perform(click());
-            onView(withText("number of good answers = 0"))
+        onView(withText("number of good answers = 0"))
                 .inRoot(
                         withDecorView(
                                 Matchers.not(

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizFragmentsTestUsingDB.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizFragmentsTestUsingDB.java
@@ -1,6 +1,7 @@
 package ch.epfl.qedit.quiz;
 
-import static ch.epfl.qedit.util.Util.createMockQuiz;
+import static ch.epfl.qedit.util.Util.createTestQuiz;
+import static ch.epfl.qedit.util.Util.createTestStringPool;
 
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
@@ -28,7 +29,7 @@ public class QuizFragmentsTestUsingDB {
                 new ViewModelProvider((ViewModelStoreOwner) testRule.getActivity())
                         .get(QuizViewModel.class);
 
-        model.setQuiz(createMockQuiz("Test Title"));
+        model.initialize(createTestQuiz(), createTestStringPool("Test Title"));
 
         testRule.launchFragment(fragment);
 

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizFragmentsTestUsingDB.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizFragmentsTestUsingDB.java
@@ -1,7 +1,6 @@
 package ch.epfl.qedit.quiz;
 
-import static ch.epfl.qedit.util.Util.createTestQuiz;
-import static ch.epfl.qedit.util.Util.createTestStringPool;
+import static ch.epfl.qedit.util.Util.createInstantiatedTestQuiz;
 
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
@@ -29,7 +28,7 @@ public class QuizFragmentsTestUsingDB {
                 new ViewModelProvider((ViewModelStoreOwner) testRule.getActivity())
                         .get(QuizViewModel.class);
 
-        model.initialize(createTestQuiz(), createTestStringPool("Test Title"));
+        model.setQuiz(createInstantiatedTestQuiz("Test Title"));
 
         testRule.launchFragment(fragment);
 

--- a/app/src/androidTest/java/ch/epfl/qedit/util/Util.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/util/Util.java
@@ -8,6 +8,7 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static ch.epfl.qedit.model.StringPool.TITLE_ID;
 
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
@@ -15,30 +16,40 @@ import androidx.test.espresso.matcher.ViewMatchers;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
 import ch.epfl.qedit.model.Quiz;
-import java.util.Arrays;
+import ch.epfl.qedit.model.StringPool;
+import java.util.HashMap;
 
 public final class Util {
 
     private Util() {};
 
-    public static Quiz createMockQuiz(String title) {
-        return new Quiz(
-                title,
-                Arrays.asList(
-                        new Question(
-                                "The matches problem",
-                                "How many matches can fit in a shoe of size 43?",
-                                "matrix3x3"),
-                        new Question(
-                                "Pigeons",
-                                "How many pigeons are there on Earth? (Hint: do not count yourself)",
-                                "matrix1x1"),
-                        new Question("KitchenBu", "Oyster", "matrix1x1"),
-                        new Question(
-                                "Everything",
-                                "What is the answer to life the universe and everything?",
-                                "matrix3x3"),
-                        new Question("Banane", "Combien y a-t-il de bananes ?", "matrix1x1")));
+    public static Quiz createTestQuiz() {
+        Quiz.Builder builder = new Quiz.Builder();
+        builder.append(new Question("q1_title", "q1_text", "matrix3x3"))
+                .append(new Question("q2_title", "q2_text", "matrix1x1"))
+                .append(new Question("q3_title", "q3_text", "matrix1x1"))
+                .append(new Question("q4_title", "q4_text", "matrix3x3"))
+                .append(new Question("q5_title", "q5_text", "matrix1x1"));
+
+        return builder.build();
+    }
+
+    public static StringPool createTestStringPool(String title) {
+        HashMap<String, String> stringPool = new HashMap<>();
+        stringPool.put(TITLE_ID, title);
+        stringPool.put("q1_title", "The matches problem");
+        stringPool.put("q1_text", "How many matches can fit in a shoe of size 43?");
+        stringPool.put("q2_title", "Pigeons");
+        stringPool.put(
+                "q2_text", "How many pigeons are there on Earth? (Hint: do not count yourself)");
+        stringPool.put("q3_title", "KitchenBu");
+        stringPool.put("q3_text", "Oyster");
+        stringPool.put("q4_title", "Everything");
+        stringPool.put("q4_text", "What is the answer to life the universe and everything?");
+        stringPool.put("q5_title", "Bananas");
+        stringPool.put("q5_text", "How many bananas are there?");
+
+        return new StringPool(stringPool);
     }
 
     public static void isDisplayed(int id, boolean scrollTo) {

--- a/app/src/androidTest/java/ch/epfl/qedit/util/Util.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/util/Util.java
@@ -52,6 +52,10 @@ public final class Util {
         return new StringPool(stringPool);
     }
 
+    public static Quiz createInstantiatedTestQuiz(String title) {
+        return createTestQuiz().instantiateLanguage(createTestStringPool(title));
+    }
+
     public static void isDisplayed(int id, boolean scrollTo) {
         if (scrollTo)
             onView(withId(id)).perform(scrollTo()).check(matches(ViewMatchers.isDisplayed()));

--- a/app/src/main/java/ch/epfl/qedit/backend/auth/MockAuthService.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/auth/MockAuthService.java
@@ -19,7 +19,7 @@ public class MockAuthService implements AuthenticationService {
             new HashMap<String, Response<User>>() {
                 {
                     //noinspection SpellCheckingInspection
-                    put("fjd4ywnzcCcLHaVb7oKg", Response.<User>error(CONNECTION_ERROR));
+                    put("fjd4ywnzcCcLHaVb7oKg", Response.error(CONNECTION_ERROR));
                     //noinspection SpellCheckingInspection
                     put("fjd4ywnzXCXLHaVb7oKg", Response.ok(createMarcel()));
                     //noinspection SpellCheckingInspection
@@ -32,23 +32,20 @@ public class MockAuthService implements AuthenticationService {
     public void sendRequest(final String token, final Callback<Response<User>> responseCallback) {
         idlingResource.increment();
         new Thread(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    Thread.sleep(2000);
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-
-                                Response<User> response;
-                                if (!userResponses.containsKey(token))
-                                    response = Response.error(WRONG_TOKEN);
-                                else response = userResponses.get(token);
-
-                                idlingResource.decrement();
-                                responseCallback.onReceive(response);
+                        () -> {
+                            try {
+                                Thread.sleep(2000);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
                             }
+
+                            Response<User> response;
+                            if (!userResponses.containsKey(token))
+                                response = Response.error(WRONG_TOKEN);
+                            else response = userResponses.get(token);
+
+                            idlingResource.decrement();
+                            responseCallback.onReceive(response);
                         })
                 .start();
     }
@@ -59,24 +56,24 @@ public class MockAuthService implements AuthenticationService {
 
     private User createMarcel() {
         User marcel = new User("Marcel", "Doe");
-        marcel.addQuiz("quiz0", "Qualification EPFL");
+        marcel.addQuiz("quiz0", "I am a Mock Quiz!");
 
         return marcel;
     }
 
     private User createCosme() {
         User cosme = new User("Cosme", "Jordan");
-        cosme.addQuiz("quiz0", "Qualification EPFL");
+        cosme.addQuiz("quiz0", "I am a Mock Quiz!");
 
         return cosme;
     }
 
     private User createAnthony() {
         User anthony = new User("Anthony", "Iozzia");
-        anthony.addQuiz("quiz0", "Quiz 0");
-        anthony.addQuiz("quiz1", "Quiz 1");
-        anthony.addQuiz("quiz2", "Quiz 2");
-        anthony.addQuiz("quiz3", "Quiz 3");
+        anthony.addQuiz("quiz0", "I am a Mock Quiz!");
+        anthony.addQuiz("quiz1", "An other Quiz");
+        anthony.addQuiz("quiz2", "An other Quiz");
+        anthony.addQuiz("quiz3", "An other Quiz");
 
         return anthony;
     }

--- a/app/src/main/java/ch/epfl/qedit/model/StringPool.java
+++ b/app/src/main/java/ch/epfl/qedit/model/StringPool.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  */
 public class StringPool implements Serializable {
 
-    public static final String TITLE_ID = "title";
+    public static final String TITLE_ID = "main_title";
 
     private Map<String, String> stringPool;
     private String languageCode;

--- a/app/src/main/java/ch/epfl/qedit/view/edit/EditOverviewFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/edit/EditOverviewFragment.java
@@ -97,11 +97,7 @@ public class EditOverviewFragment extends Fragment {
 
         // Add the titles of all question already in the builder to a list
         for (Question question : model.getQuizBuilder().getQuestions()) {
-            String key = question.getTitle();
-            String text = model.getStringPool().get(key);
-
-            // TODO Support old questions that store the strings directly as well
-            titles.add((text == null) ? key : text);
+            titles.add(model.getStringPool().get(question.getTitle()));
         }
 
         handleEmptyHint();

--- a/app/src/main/java/ch/epfl/qedit/view/edit/EditPreviewFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/edit/EditPreviewFragment.java
@@ -56,15 +56,8 @@ public class EditPreviewFragment extends Fragment {
         Question question = quizBuilder.getQuestions().get(index);
         StringPool stringPool = model.getStringPool();
 
-        // Update the title of the question
-        String key =
-                question.getTitle(); // TODO Support old questions that store the strings directly
-        String text = stringPool.get(key);
-        questionTitle.setText((text == null) ? key : text);
-
-        // Update the text of the question
-        key = question.getText();
-        text = stringPool.get(key);
-        questionDisplay.setText((text == null) ? key : text);
+        // Update EditText
+        questionTitle.setText(stringPool.get(question.getTitle()));
+        questionDisplay.setText(stringPool.get(question.getText()));
     }
 }

--- a/app/src/main/java/ch/epfl/qedit/view/edit/EditSettingsActivity.java
+++ b/app/src/main/java/ch/epfl/qedit/view/edit/EditSettingsActivity.java
@@ -74,10 +74,7 @@ public class EditSettingsActivity extends AppCompatActivity
 
         // Set the EditText for the title
         editTitle = findViewById(R.id.edit_quiz_title);
-
-        String title = stringPool.get(TITLE_ID);
-        // TODO Support old questions that store the strings directly as well
-        editTitle.setText((title == null) ? quiz.getTitle() : title);
+        editTitle.setText(stringPool.get(TITLE_ID));
     }
 
     private void createTreasureHuntCheckbox() {

--- a/app/src/main/java/ch/epfl/qedit/view/quiz/QuestionFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/quiz/QuestionFragment.java
@@ -8,11 +8,11 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
 import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerFormat;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import ch.epfl.qedit.viewmodel.QuizViewModel;
@@ -44,12 +44,7 @@ public class QuestionFragment extends Fragment {
                 .getFocusedQuestion()
                 .observe(
                         getViewLifecycleOwner(),
-                        new Observer<Integer>() {
-                            @Override
-                            public void onChanged(Integer index) {
-                                onQuestionChanged(quizViewModel.getQuiz(), index);
-                            }
-                        });
+                        index -> onQuestionChanged(quizViewModel.getQuiz(), index));
 
         return view;
     }
@@ -60,12 +55,14 @@ public class QuestionFragment extends Fragment {
             return;
         }
 
+        StringPool stringPool = quizViewModel.getStringPool();
         Question question = quiz.getQuestions().get(index);
 
         // We have to change the question title and text
-        String questionTitleStr = "Question " + (index + 1) + " - " + question.getTitle();
+        String questionTitleStr =
+                "Question " + (index + 1) + " - " + stringPool.get(question.getTitle());
         questionTitle.setText(questionTitleStr);
-        questionDisplay.setText(question.getText());
+        questionDisplay.setText(stringPool.get(question.getText()));
 
         // Set everything up for the concrete AnswerFragment and launch it
         prepareAnswerFormatFragment(question, index);

--- a/app/src/main/java/ch/epfl/qedit/view/quiz/QuestionFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/quiz/QuestionFragment.java
@@ -12,7 +12,6 @@ import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
 import ch.epfl.qedit.model.Quiz;
-import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerFormat;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import ch.epfl.qedit.viewmodel.QuizViewModel;
@@ -55,14 +54,12 @@ public class QuestionFragment extends Fragment {
             return;
         }
 
-        StringPool stringPool = quizViewModel.getStringPool();
         Question question = quiz.getQuestions().get(index);
 
         // We have to change the question title and text
-        String questionTitleStr =
-                "Question " + (index + 1) + " - " + stringPool.get(question.getTitle());
+        String questionTitleStr = "Question " + (index + 1) + " - " + question.getTitle();
         questionTitle.setText(questionTitleStr);
-        questionDisplay.setText(stringPool.get(question.getText()));
+        questionDisplay.setText(question.getText());
 
         // Set everything up for the concrete AnswerFragment and launch it
         prepareAnswerFormatFragment(question, index);

--- a/app/src/main/java/ch/epfl/qedit/view/quiz/QuizActivity.java
+++ b/app/src/main/java/ch/epfl/qedit/view/quiz/QuizActivity.java
@@ -1,6 +1,7 @@
 package ch.epfl.qedit.view.quiz;
 
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.QUIZ_ID;
+import static ch.epfl.qedit.view.home.HomeQuizListFragment.STRING_POOL;
 
 import android.content.Context;
 import android.content.Intent;
@@ -16,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
 import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import ch.epfl.qedit.util.LocaleHelper;
 import ch.epfl.qedit.view.util.ConfirmDialog;
@@ -30,6 +32,7 @@ public class QuizActivity extends AppCompatActivity implements ConfirmDialog.Con
 
     private ConfirmDialog validateDialog;
     private Quiz quiz;
+    private StringPool stringPool;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,9 +42,12 @@ public class QuizActivity extends AppCompatActivity implements ConfirmDialog.Con
         // Get the Intent that started this activity and extract the quiz
         Intent intent = getIntent();
         quiz = (Quiz) Objects.requireNonNull(intent.getExtras()).getSerializable(QUIZ_ID);
+        stringPool =
+                (StringPool)
+                        Objects.requireNonNull(intent.getExtras()).getSerializable(STRING_POOL);
 
         model = new ViewModelProvider(this).get(QuizViewModel.class);
-        model.setQuiz(quiz);
+        model.initialize(quiz, stringPool);
 
         overviewActive = false;
         handleToggleOverview();

--- a/app/src/main/java/ch/epfl/qedit/view/quiz/QuizActivity.java
+++ b/app/src/main/java/ch/epfl/qedit/view/quiz/QuizActivity.java
@@ -1,7 +1,6 @@
 package ch.epfl.qedit.view.quiz;
 
 import static ch.epfl.qedit.view.home.HomeQuizListFragment.QUIZ_ID;
-import static ch.epfl.qedit.view.home.HomeQuizListFragment.STRING_POOL;
 
 import android.content.Context;
 import android.content.Intent;
@@ -17,7 +16,6 @@ import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
 import ch.epfl.qedit.model.Quiz;
-import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import ch.epfl.qedit.util.LocaleHelper;
 import ch.epfl.qedit.view.util.ConfirmDialog;
@@ -32,7 +30,6 @@ public class QuizActivity extends AppCompatActivity implements ConfirmDialog.Con
 
     private ConfirmDialog validateDialog;
     private Quiz quiz;
-    private StringPool stringPool;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,12 +39,9 @@ public class QuizActivity extends AppCompatActivity implements ConfirmDialog.Con
         // Get the Intent that started this activity and extract the quiz
         Intent intent = getIntent();
         quiz = (Quiz) Objects.requireNonNull(intent.getExtras()).getSerializable(QUIZ_ID);
-        stringPool =
-                (StringPool)
-                        Objects.requireNonNull(intent.getExtras()).getSerializable(STRING_POOL);
 
         model = new ViewModelProvider(this).get(QuizViewModel.class);
-        model.initialize(quiz, stringPool);
+        model.setQuiz(quiz);
 
         overviewActive = false;
         handleToggleOverview();

--- a/app/src/main/java/ch/epfl/qedit/view/quiz/QuizOverviewFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/quiz/QuizOverviewFragment.java
@@ -4,14 +4,13 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
-import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.viewmodel.QuizViewModel;
 import java.util.List;
 
@@ -19,6 +18,7 @@ import java.util.List;
 public class QuizOverviewFragment extends Fragment {
 
     private ListView listView;
+    private QuizViewModel quizViewModel;
 
     @Override
     public View onCreateView(
@@ -28,32 +28,28 @@ public class QuizOverviewFragment extends Fragment {
         listView = view.findViewById(R.id.question_list);
 
         // Listen to the quiz live data
-        final QuizViewModel model =
-                new ViewModelProvider(requireActivity()).get(QuizViewModel.class);
-        setupListView(model.getQuiz());
+        quizViewModel = new ViewModelProvider(requireActivity()).get(QuizViewModel.class);
+        setupListView();
 
         listView.setOnItemClickListener(
-                new AdapterView.OnItemClickListener() {
-                    @Override
-                    public void onItemClick(
-                            AdapterView<?> parent, View view, int position, long id) {
-                        // We change the question that is focused when the corresponding list item
-                        // is selected
-                        model.getFocusedQuestion().postValue(position);
-                    }
+                (parent, view1, position, id) -> {
+                    // We change the question that is focused when the corresponding list item
+                    // is selected
+                    quizViewModel.getFocusedQuestion().postValue(position);
                 });
 
         return view;
     }
 
     /** Handles the initialization of the ListView showing the list of questions */
-    private void setupListView(Quiz quiz) {
-        List<Question> questions = quiz.getQuestions();
+    private void setupListView() {
+        List<Question> questions = quizViewModel.getQuiz().getQuestions();
+        StringPool stringPool = quizViewModel.getStringPool();
         String[] overviewItems = new String[questions.size()];
 
         // For each question of the quiz, we create an item in the list view
         for (int i = 0; i < questions.size(); ++i) {
-            String title = questions.get(i).getTitle();
+            String title = stringPool.get(questions.get(i).getTitle());
             overviewItems[i] = (i + 1) + ") " + title;
         }
 

--- a/app/src/main/java/ch/epfl/qedit/view/quiz/QuizOverviewFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/quiz/QuizOverviewFragment.java
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import ch.epfl.qedit.R;
 import ch.epfl.qedit.model.Question;
-import ch.epfl.qedit.model.StringPool;
+import ch.epfl.qedit.model.Quiz;
 import ch.epfl.qedit.viewmodel.QuizViewModel;
 import java.util.List;
 
@@ -18,7 +18,6 @@ import java.util.List;
 public class QuizOverviewFragment extends Fragment {
 
     private ListView listView;
-    private QuizViewModel quizViewModel;
 
     @Override
     public View onCreateView(
@@ -28,28 +27,28 @@ public class QuizOverviewFragment extends Fragment {
         listView = view.findViewById(R.id.question_list);
 
         // Listen to the quiz live data
-        quizViewModel = new ViewModelProvider(requireActivity()).get(QuizViewModel.class);
-        setupListView();
+        final QuizViewModel model =
+                new ViewModelProvider(requireActivity()).get(QuizViewModel.class);
+        setupListView(model.getQuiz());
 
         listView.setOnItemClickListener(
                 (parent, view1, position, id) -> {
                     // We change the question that is focused when the corresponding list item
                     // is selected
-                    quizViewModel.getFocusedQuestion().postValue(position);
+                    model.getFocusedQuestion().postValue(position);
                 });
 
         return view;
     }
 
     /** Handles the initialization of the ListView showing the list of questions */
-    private void setupListView() {
-        List<Question> questions = quizViewModel.getQuiz().getQuestions();
-        StringPool stringPool = quizViewModel.getStringPool();
+    private void setupListView(Quiz quiz) {
+        List<Question> questions = quiz.getQuestions();
         String[] overviewItems = new String[questions.size()];
 
         // For each question of the quiz, we create an item in the list view
         for (int i = 0; i < questions.size(); ++i) {
-            String title = stringPool.get(questions.get(i).getTitle());
+            String title = questions.get(i).getTitle();
             overviewItems[i] = (i + 1) + ") " + title;
         }
 

--- a/app/src/main/java/ch/epfl/qedit/viewmodel/QuizViewModel.java
+++ b/app/src/main/java/ch/epfl/qedit/viewmodel/QuizViewModel.java
@@ -3,23 +3,31 @@ package ch.epfl.qedit.viewmodel;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import java.util.HashMap;
 
 public class QuizViewModel extends ViewModel {
     private final MutableLiveData<Integer> focusedQuestion = new MutableLiveData<>(null);
     private final MutableLiveData<HashMap<Integer, AnswerModel>> answers =
-            new MutableLiveData<>(new HashMap<Integer, AnswerModel>());
-    private Quiz quiz = null;
+            new MutableLiveData<>(new HashMap<>());
 
-    public void setQuiz(Quiz quiz) {
-        if (this.quiz == null) {
+    private Quiz quiz = null;
+    private StringPool stringPool = null;
+
+    public void initialize(Quiz quiz, StringPool stringPool) {
+        if (this.quiz == null && this.stringPool == null) {
             this.quiz = quiz;
+            this.stringPool = stringPool;
         }
     }
 
     public Quiz getQuiz() {
         return quiz;
+    }
+
+    public StringPool getStringPool() {
+        return stringPool;
     }
 
     public MutableLiveData<Integer> getFocusedQuestion() {

--- a/app/src/main/java/ch/epfl/qedit/viewmodel/QuizViewModel.java
+++ b/app/src/main/java/ch/epfl/qedit/viewmodel/QuizViewModel.java
@@ -3,7 +3,6 @@ package ch.epfl.qedit.viewmodel;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import ch.epfl.qedit.model.Quiz;
-import ch.epfl.qedit.model.StringPool;
 import ch.epfl.qedit.model.answer.AnswerModel;
 import java.util.HashMap;
 
@@ -11,23 +10,16 @@ public class QuizViewModel extends ViewModel {
     private final MutableLiveData<Integer> focusedQuestion = new MutableLiveData<>(null);
     private final MutableLiveData<HashMap<Integer, AnswerModel>> answers =
             new MutableLiveData<>(new HashMap<>());
-
     private Quiz quiz = null;
-    private StringPool stringPool = null;
 
-    public void initialize(Quiz quiz, StringPool stringPool) {
-        if (this.quiz == null && this.stringPool == null) {
+    public void setQuiz(Quiz quiz) {
+        if (this.quiz == null) {
             this.quiz = quiz;
-            this.stringPool = stringPool;
         }
     }
 
     public Quiz getQuiz() {
         return quiz;
-    }
-
-    public StringPool getStringPool() {
-        return stringPool;
     }
 
     public MutableLiveData<Integer> getFocusedQuestion() {


### PR DESCRIPTION
Use only questions that do not store the titles and texts directly any more. Instead add `StringPools` where needed. Additionally I unified the usage of quiz titles across the app. Every user should now have the same quizzes in the `AuthService` and in the `DBService`.

I had to add a `StringPool` to the `QuizViewModel`.