### PR TITLE
Cache data for offline experience

### DIFF
--- a/app/src/androidTest/java/ch/epfl/qedit/backend/CacheDBServiceTest.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/backend/CacheDBServiceTest.java
@@ -1,0 +1,72 @@
+package ch.epfl.qedit.backend;
+
+import static ch.epfl.qedit.backend.auth.MockAuthService.ANTHONY_IOZZIA_ID;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import ch.epfl.qedit.backend.database.CacheDBService;
+import ch.epfl.qedit.backend.database.MockDBService;
+import ch.epfl.qedit.model.User;
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class CacheDBServiceTest {
+    private Context context = ApplicationProvider.getApplicationContext();
+    private File cacheDir = context.getCacheDir();
+
+    private MockDBService db;
+    private CacheDBService cache;
+
+    // Recursively deletes a file or a directory
+    private void delete(File fileOrDir) {
+        if (fileOrDir.isDirectory()) {
+            for (File child : fileOrDir.listFiles()) delete(child);
+        }
+
+        fileOrDir.delete();
+    }
+
+    // Clears all the files that might have been cached in the phone's internal storage
+    private void clearCache() {
+        delete(new File(cacheDir, "users"));
+        delete(new File(cacheDir, "quizzes"));
+        delete(new File(cacheDir, "pools"));
+        delete(new File(cacheDir, "languages"));
+    }
+
+    @Before
+    public void init() {
+        clearCache();
+
+        // We instantiate the DB service using Mockito's spy feature to monitor the calls
+        db = spy(new MockDBService());
+        cache = new CacheDBService(db, context);
+    }
+
+    @After
+    public void cleanup() {
+        clearCache();
+    }
+
+    @Test
+    public void testCacheCachesRequests() {
+        CompletableFuture<User> f1 = cache.getUser(ANTHONY_IOZZIA_ID);
+        CompletableFuture<User> f2 = cache.getUser(ANTHONY_IOZZIA_ID);
+
+        User u1 = f1.join();
+        User u2 = f2.join();
+
+        verify(db, times(1)).getUser(ANTHONY_IOZZIA_ID);
+        assertEquals(u1, u2);
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/qedit/home/HomeFragmentsTestUsingDB.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/home/HomeFragmentsTestUsingDB.java
@@ -31,7 +31,7 @@ class HomeFragmentsTestUsingDB extends RecyclerViewHelpers {
 
         MockDBService dbService = new MockDBService();
         idlingResource = dbService.getIdlingResource();
-        DatabaseFactory.setInstance(dbService);
+        DatabaseFactory.setInstance(context -> dbService);
         IdlingRegistry.getInstance().register(idlingResource);
 
         testRule.launchFragment(fragment);

--- a/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizFragmentsTestUsingDB.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/quiz/QuizFragmentsTestUsingDB.java
@@ -22,7 +22,7 @@ public class QuizFragmentsTestUsingDB {
         MockDBService dbService = new MockDBService();
         idlingResource = dbService.getIdlingResource();
         IdlingRegistry.getInstance().register(idlingResource);
-        DatabaseFactory.setInstance(dbService);
+        DatabaseFactory.setInstance(context -> dbService);
 
         QuizViewModel model =
                 new ViewModelProvider((ViewModelStoreOwner) testRule.getActivity())

--- a/app/src/androidTest/java/ch/epfl/qedit/util/Util.java
+++ b/app/src/androidTest/java/ch/epfl/qedit/util/Util.java
@@ -71,7 +71,7 @@ public final class Util {
         IdlingResource idlingResource = authService.getIdlingResource();
         IdlingRegistry.getInstance().register(idlingResource);
         AuthenticationFactory.setInstance(authService);
-        DatabaseFactory.setInstance(dbService);
+        DatabaseFactory.setInstance(context -> dbService);
         testRule.launchActivity(null);
         Intents.init();
         Espresso.closeSoftKeyboard();

--- a/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
@@ -1,26 +1,30 @@
 package ch.epfl.qedit.backend.database;
 
+import android.content.Context;
+import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
+import ch.epfl.qedit.model.User;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import ch.epfl.qedit.model.Quiz;
-import ch.epfl.qedit.model.StringPool;
-import ch.epfl.qedit.model.User;
-
 /**
- * This class decorates a database service so that some of the requests are cached on the
- * internal storage. This is used to reduce the delay of accessing the database and allowing
- * the user to use the app without internet connection.
+ * This class decorates a database service so that some of the requests are cached on the internal
+ * storage. This is used to reduce the delay of accessing the database and allowing the user to use
+ * the app without internet connection.
  */
 public class CacheDBService implements DatabaseService {
 
     // This is the underlying database service that is being decorated
     private final DatabaseService dbService;
 
+    // This is the context of the application, that we need in order to access the cache
+    private final Context context;
+
     /** Creates a cache that decorates the given database service */
-    public CacheDBService(DatabaseService dbService) {
+    public CacheDBService(DatabaseService dbService, Context context) {
         this.dbService = dbService;
+        this.context = context;
     }
 
     @Override
@@ -54,12 +58,17 @@ public class CacheDBService implements DatabaseService {
     }
 
     @Override
-    public CompletableFuture<Void> updateUserStatistics(String userId, int score, int successes, int attempts) {
+    public CompletableFuture<Void> updateUserStatistics(
+            String userId, int score, int successes, int attempts) {
         return dbService.updateUserStatistics(userId, score, successes, attempts);
     }
 
     @Override
     public CompletableFuture<Void> updateUserQuizList(String userId, Map<String, String> quizzes) {
         return dbService.updateUserQuizList(userId, quizzes);
+    }
+
+    private static User getUserFromCache(String userId) {
+        return null;
     }
 }

--- a/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
@@ -1,0 +1,65 @@
+package ch.epfl.qedit.backend.database;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import ch.epfl.qedit.model.Quiz;
+import ch.epfl.qedit.model.StringPool;
+import ch.epfl.qedit.model.User;
+
+/**
+ * This class decorates a database service so that some of the requests are cached on the
+ * internal storage. This is used to reduce the delay of accessing the database and allowing
+ * the user to use the app without internet connection.
+ */
+public class CacheDBService implements DatabaseService {
+
+    // This is the underlying database service that is being decorated
+    private final DatabaseService dbService;
+
+    /** Creates a cache that decorates the given database service */
+    public CacheDBService(DatabaseService dbService) {
+        this.dbService = dbService;
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getQuizLanguages(String quizId) {
+        return dbService.getQuizLanguages(quizId);
+    }
+
+    @Override
+    public CompletableFuture<Quiz> getQuizStructure(String quizId) {
+        return dbService.getQuizStructure(quizId);
+    }
+
+    @Override
+    public CompletableFuture<StringPool> getQuizStringPool(String quizId, String language) {
+        return dbService.getQuizStringPool(quizId, language);
+    }
+
+    @Override
+    public CompletableFuture<String> uploadQuiz(Quiz quiz, StringPool stringPool) {
+        return dbService.uploadQuiz(quiz, stringPool);
+    }
+
+    @Override
+    public CompletableFuture<User> getUser(String userId) {
+        return dbService.getUser(userId);
+    }
+
+    @Override
+    public CompletableFuture<Void> createUser(String userId, String firstName, String lastName) {
+        return dbService.createUser(userId, firstName, lastName);
+    }
+
+    @Override
+    public CompletableFuture<Void> updateUserStatistics(String userId, int score, int successes, int attempts) {
+        return dbService.updateUserStatistics(userId, score, successes, attempts);
+    }
+
+    @Override
+    public CompletableFuture<Void> updateUserQuizList(String userId, Map<String, String> quizzes) {
+        return dbService.updateUserQuizList(userId, quizzes);
+    }
+}

--- a/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
@@ -41,8 +41,15 @@ public class CacheDBService implements DatabaseService {
         this.poolCacheDir = new File(context.getCacheDir(), "pools");
         this.langCacheDir = new File(context.getCacheDir(), "languages");
 
-        // Create an empty directory if it does not already exist
-        if (!userCacheDir.exists()) userCacheDir.mkdirs();
+        // Create the subdirectories if they do not already exist
+        createDir(userCacheDir);
+        createDir(quizCacheDir);
+        createDir(poolCacheDir);
+        createDir(langCacheDir);
+    }
+
+    private static void createDir(File dir) {
+        if (!dir.exists()) dir.mkdirs();
     }
 
     @Override
@@ -66,7 +73,7 @@ public class CacheDBService implements DatabaseService {
     @Override
     public CompletableFuture<StringPool> getQuizStringPool(String quizId, String language) {
         return retrieve(
-                new File(quizCacheDir, quizId + "-" + language),
+                new File(poolCacheDir, quizId + "-" + language),
                 () -> dbService.getQuizStringPool(quizId, language));
     }
 

--- a/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/database/CacheDBService.java
@@ -10,9 +10,11 @@ import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -27,13 +29,19 @@ public class CacheDBService implements DatabaseService {
     // This is the underlying database service that is being decorated
     private final DatabaseService dbService;
 
-    // This it the cache directory
+    // These are the directories in which we cache the data
     private final File userCacheDir;
+    private final File quizCacheDir;
+    private final File poolCacheDir;
+    private final File langCacheDir;
 
     /** Creates a cache that decorates the given database service */
     public CacheDBService(DatabaseService dbService, Context context) {
         this.dbService = dbService;
         this.userCacheDir = new File(context.getCacheDir(), "users");
+        this.quizCacheDir = new File(context.getCacheDir(), "quizzes");
+        this.poolCacheDir = new File(context.getCacheDir(), "pools");
+        this.langCacheDir = new File(context.getCacheDir(), "languages");
 
         // Create an empty directory if it does not already exist
         if (!userCacheDir.exists()) userCacheDir.mkdirs();
@@ -41,17 +49,27 @@ public class CacheDBService implements DatabaseService {
 
     @Override
     public CompletableFuture<List<String>> getQuizLanguages(String quizId) {
-        return dbService.getQuizLanguages(quizId);
+        // Lists are not serializable, but array lists are, so we just need to wrap the lists
+        // into array lists before storing them in the cache. Since array lists are lists,
+        // nothing needs to be done to deserialize.
+        return retrieve(
+                new File(langCacheDir, quizId),
+                () -> dbService.getQuizLanguages(quizId),
+                list -> new ArrayList<>(list),
+                list -> list // cannot use Function.identity() because of the type system
+                );
     }
 
     @Override
     public CompletableFuture<Quiz> getQuizStructure(String quizId) {
-        return dbService.getQuizStructure(quizId);
+        return retrieve(new File(quizCacheDir, quizId), () -> dbService.getQuizStructure(quizId));
     }
 
     @Override
     public CompletableFuture<StringPool> getQuizStringPool(String quizId, String language) {
-        return dbService.getQuizStringPool(quizId, language);
+        return retrieve(
+                new File(quizCacheDir, quizId + "-" + language),
+                () -> dbService.getQuizStringPool(quizId, language));
     }
 
     @Override
@@ -127,30 +145,48 @@ public class CacheDBService implements DatabaseService {
     }
 
     /**
-     * Performs a retrieval from the cache or the database, depending on their availability. The
+     * * Performs a retrieval from the cache or the database, depending on their availability. The
      * data is first searched in the cache. If it is not present there, it is fetched from the
      * database and stored in the cache for the next retrievals.
+     *
+     * @param cache the file in which the data should be stored
+     * @param database a function that requests the data from the database, if needed
+     * @param serialize a function that serializes the data before file storage
+     * @param deserialize a function that deserializes the data when being loaded from the cache
+     * @param <S> the type of the data
+     * @param <T> the type of the data, once serialized to the cache
+     * @return a future that complete once the full retrieval was performed
      */
-    private <T extends Serializable> CompletableFuture<T> retrieve(
-            File cache, Supplier<CompletableFuture<T>> database) {
+    private <S, T extends Serializable> CompletableFuture<S> retrieve(
+            File cache,
+            Supplier<CompletableFuture<S>> database,
+            Function<S, T> serialize,
+            Function<T, S> deserialize) {
         return lookup(cache)
                 .thenCompose(
                         fromCache -> {
                             if (fromCache != null) {
                                 // If the data is already available, we can return it immediately
-                                return CompletableFuture.<T>completedFuture(fromCache);
+                                return CompletableFuture.<S>completedFuture(
+                                        deserialize.apply((T) fromCache));
                             } else {
                                 // Otherwise, we fetch it from the real database
-                                CompletableFuture<T> f = database.get();
+                                CompletableFuture<S> f = database.get();
 
                                 // Once it arrives, we cache it locally
                                 f.thenAccept(
                                         fromDB -> {
-                                            storeInCache(cache, fromDB);
+                                            storeInCache(cache, serialize.apply(fromDB));
                                         });
 
                                 return f;
                             }
                         });
+    }
+
+    /** Same version as above, when the data type is already serializable */
+    private <T extends Serializable> CompletableFuture<T> retrieve(
+            File cache, Supplier<CompletableFuture<T>> database) {
+        return retrieve(cache, database, Function.identity(), Function.identity());
     }
 }

--- a/app/src/main/java/ch/epfl/qedit/backend/database/DatabaseFactory.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/database/DatabaseFactory.java
@@ -1,5 +1,8 @@
 package ch.epfl.qedit.backend.database;
 
+import android.content.Context;
+import java.util.function.Function;
+
 /**
  * This factory class is used to manage the singleton instance of a database service. It can be used
  * by android tests to inject mock dependencies.
@@ -8,17 +11,27 @@ public final class DatabaseFactory {
     /** The singleton instance of the auth service */
     private static DatabaseService dbService = null;
 
+    /** The callback used to instantiate a new instance, once the context was acquired */
+    private static Function<Context, DatabaseService> builder = null;
+
     private DatabaseFactory() {}
 
-    public static DatabaseService getInstance() {
+    public static DatabaseService getInstance(Context context) {
         if (dbService == null) {
-            dbService = new MockDBService();
+            if (builder == null) dbService = new MockDBService();
+            else dbService = builder.apply(context);
         }
 
         return dbService;
     }
 
-    public static void setInstance(DatabaseService service) {
-        dbService = service;
+    /**
+     * Sets the singleton database service. Since the context is required to build a DB service, a
+     * function is passed instead of the actual service.
+     *
+     * @param builder the builder that will construct the service, once the context is known.
+     */
+    public static void setInstance(Function<Context, DatabaseService> builder) {
+        DatabaseFactory.builder = builder;
     }
 }

--- a/app/src/main/java/ch/epfl/qedit/backend/location/LocServiceFactory.java
+++ b/app/src/main/java/ch/epfl/qedit/backend/location/LocServiceFactory.java
@@ -11,7 +11,7 @@ public final class LocServiceFactory {
     /** The singleton instance of the location service */
     private static LocationService locService = null;
 
-    /** The callback used to instantiate a new instance, once the context was aquired */
+    /** The callback used to instantiate a new instance, once the context was acquired */
     private static Function<Context, LocationService> builder = null;
 
     public static LocationService getInstance(Context context) {

--- a/app/src/main/java/ch/epfl/qedit/view/home/HomeQuizListFragment.java
+++ b/app/src/main/java/ch/epfl/qedit/view/home/HomeQuizListFragment.java
@@ -89,7 +89,7 @@ public class HomeQuizListFragment extends Fragment
         progressBar = view.findViewById(R.id.quiz_loading);
 
         // Instantiate Handler and the DatabaseService
-        db = DatabaseFactory.getInstance();
+        db = DatabaseFactory.getInstance(requireContext());
 
         return view;
     }

--- a/app/src/main/java/ch/epfl/qedit/view/login/LogInActivity.java
+++ b/app/src/main/java/ch/epfl/qedit/view/login/LogInActivity.java
@@ -152,7 +152,7 @@ public class LogInActivity extends AppCompatActivity implements AdapterView.OnIt
 
         // We extract the complete user information from the database thanks to the user id given by
         // the authentication service
-        DatabaseService db = DatabaseFactory.getInstance();
+        DatabaseService db = DatabaseFactory.getInstance(getApplicationContext());
         db.getUser(userId)
                 .whenComplete(
                         (user, throwable) -> {

--- a/app/src/main/java/ch/epfl/qedit/view/login/SignUpActivity.java
+++ b/app/src/main/java/ch/epfl/qedit/view/login/SignUpActivity.java
@@ -191,7 +191,7 @@ public class SignUpActivity extends AppCompatActivity
     private void onSignUpSuccessful(String userId) {
         Intent intent = new Intent(this, LogInActivity.class);
 
-        DatabaseService db = DatabaseFactory.getInstance();
+        DatabaseService db = DatabaseFactory.getInstance(getApplicationContext());
         db.createUser(userId, firstName, lastName)
                 .whenComplete(
                         (result, throwable) -> {


### PR DESCRIPTION
This PR will add a decorator database service that caches requests to the real database so that it can be accessed faster, and potentially without internet connection. We will first focus on caching users, so that the login can be done offline, and then we will tackle storing quizzes.